### PR TITLE
Fix compile warning

### DIFF
--- a/hidReportDescriptor.h
+++ b/hidReportDescriptor.h
@@ -14,4 +14,4 @@
 extern const uint8_t hidReportDescriptorKeyboard[N_ELEM_KEYBOARD];
 extern const uint8_t hidReportDescriptorMouse[N_ELEM_MOUSE];
 
-#endif;
+#endif


### PR DESCRIPTION
This is to fix following compile warning.

```
/ESP32-BLE-Combo/hidReportDescriptor.h:17:7: warning: extra tokens at end of #endif directive [-Wendif-labels]
 #endif;
```